### PR TITLE
addressモデルの作成とmigrationの記述、readmeを編集

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ has_many :comments
 
 
 ## index
-add_index: [:nickname, :gender, :adress]
+add_index: [:nickname, :gender]
 
 
 
@@ -63,7 +63,7 @@ add_index: [:nickname, :gender, :adress]
 |block|string|null: false|
 |buildig|string||
 |number|integer||
-|user_id|integer|null: false, foreign_key: true|
+|user_id|references|null: false, foreign_key: true|
 
 ## Association
 belongs_to :user

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,0 +1,2 @@
+class Address < ApplicationRecord
+end

--- a/db/migrate/20200319105352_devise_create_users.rb
+++ b/db/migrate/20200319105352_devise_create_users.rb
@@ -14,7 +14,7 @@ class DeviseCreateUsers < ActiveRecord::Migration[5.0]
       t.string  :first_name_kana,    null: false
       t.string  :nickname,           null: false
       t.integer :number,             null: false
-      t.integer :gender,            null: false
+      t.integer :gender,             null: false
       t.date    :birthday,           null: false
       ## Recoverable
       t.string   :reset_password_token

--- a/db/migrate/20200320024231_create_addresses.rb
+++ b/db/migrate/20200320024231_create_addresses.rb
@@ -1,0 +1,20 @@
+class CreateAddresses < ActiveRecord::Migration[5.0]
+  def change
+    create_table :addresses do |t|
+      t.string     :family_name,             null: false
+      t.string     :first_name,              null: false
+      t.string     :family_name_kana,        null: false
+      t.string     :first_name_kana,         null: false
+      t.string     :postal_code,             null: false
+      t.string     :city,                    null: false
+      t.string     :local,                   null: false
+      t.string     :block,                   null: false
+      t.string     :building
+      t.references :user,                    null: false
+
+      t.timestamps
+    end
+    add_index       :addresses, :city
+    add_foreign_key :addresses, :users
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,24 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200319113603) do
+ActiveRecord::Schema.define(version: 20200320024231) do
+
+  create_table "addresses", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string   "family_name",      null: false
+    t.string   "first_name",       null: false
+    t.string   "family_name_kana", null: false
+    t.string   "first_name_kana",  null: false
+    t.string   "postal_code",      null: false
+    t.string   "city",             null: false
+    t.string   "local",            null: false
+    t.string   "block",            null: false
+    t.string   "building"
+    t.integer  "user_id",          null: false
+    t.datetime "created_at",       null: false
+    t.datetime "updated_at",       null: false
+    t.index ["city"], name: "index_addresses_on_city", using: :btree
+    t.index ["user_id"], name: "index_addresses_on_user_id", using: :btree
+  end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "email",                  default: "", null: false
@@ -33,4 +50,5 @@ ActiveRecord::Schema.define(version: 20200319113603) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   end
 
+  add_foreign_key "addresses", "users"
 end

--- a/test/fixtures/addresses.yml
+++ b/test/fixtures/addresses.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/address_test.rb
+++ b/test/models/address_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class AddressTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# What
addressモデルの作成とmigrationの記述、データベースに合わせてreadmeを編集

# Why
ウィザード形式でのユーザー登録の実装にあたり必要なテーブルであるため

