### PR TITLE
【マークアップ】商品詳細ページの実装

### DIFF
--- a/app/assets/stylesheets/_item_show.scss
+++ b/app/assets/stylesheets/_item_show.scss
@@ -1,0 +1,214 @@
+.d-header {
+  background-color: skyblue;
+  width: 100vw;
+  height: 100px;
+}
+
+.d-main{
+  width: 100vw;
+  height: 100%;
+  background-color: #f8f8f8;
+}
+  
+.d-showMain{
+  margin: 0 auto;
+  width: 700px;
+}
+    
+.d-content {
+  // background-color: #ffffff;
+}
+
+.d-itemBox {
+  padding: 24px 40px 40px;
+  background-color: #ffffff;
+
+  &__name {
+    font-size: 24px;
+    text-align: center;
+  }
+  
+  &__body {
+    margin: 16px 0 0;
+    ul {
+      display: flex;
+      position: relative;
+      li {
+        display: flex;
+        width: 560px;
+        align-items: center;
+        margin: 0 auto;
+        flex-direction: column;
+        ul {
+          display: flex;
+          justify-content: center;
+          margin-top: 10px;
+          li {
+            width: 25%;
+            margin: 0 10px 0 0;
+          }
+        }
+      }
+    }
+  }
+
+  &__price {
+    margin: 24px 0 24px;
+    font-size: 46px;
+    text-align: center;
+  }
+
+  &__price-detail {
+    font-size: 16px;
+  }
+
+  .d-itemDetail {
+    font-size: 18px;
+    margin-bottom: 30px;
+  }
+  
+  .d-table {
+    margin-bottom: 20px;
+    font-size: 14px;
+    table {
+      display: table;
+      width: 100%;
+      border-collapse: collapse; 
+      tbody {
+        tr {
+          border: 1px solid #dedede;
+          th {
+            background-color: #EEEEEE;
+            width: 135px;
+            padding: 8px;
+            text-align: center;
+          }
+          td {
+            padding: 15px;
+          }
+        }
+      }
+    }
+  }
+  .d-optonalArea {
+    display: flex;
+    justify-content: space-between;
+
+      ul {
+        .d-likeBtn {
+          color: #3CCACE;
+          font-size: 16px;
+          border: 1px solid #ffb340;
+          padding: 6px 10px;
+          border-radius: 40px;
+        }
+      }
+      .d-optional {
+        margin: 10px 0 0;
+        li {
+          font-size: 14px;
+          a {
+            padding: 6px 10px;
+            border: 1px solid #333;
+            border-radius: 4px;
+            text-decoration: none;
+            color: #333;
+            display: inline-block;
+          }
+        }
+      }
+  }
+}
+
+.d-optionalBtn:hover{
+  opacity: 0.5;
+}
+.d-likeBtn:hover{
+  opacity: 0.5;
+}
+
+
+.d-itemChangeBox {
+  padding: 24px 40px 40px;
+  text-align: center;
+  background-color: #ffffff;
+  
+  &__btnList {
+    &__editBtn{
+      background-color: #3CCACE;
+      border: 1px solid #3CCACE;
+      color: #fff;
+    }
+  }
+  button {
+    width: 100%;
+    font-size: 16px;
+    line-height: 48px;
+    margin: 16px 0;
+  }
+}
+
+
+.d-commentBox {
+  margin: 10px 0;
+  padding: 24px;
+  text-align: center;
+  background-color: #ffffff;
+  
+  textarea {
+    width: 100%;
+    height: 104px;
+  }
+
+  p {
+    font-size: 14px;
+    
+    text-align: left;
+  }
+  .d-noticeMsg {
+    padding: 8px;
+    margin: 10px 0;
+    background-color: #f8f8f8;
+  }
+  .d-commentBtn {
+    background: #3CCACE;
+    line-height: 48px;
+    color: #fff;
+    font-size: 18px;
+    border-radius: 100px;
+    width: 60%;
+    border: 1px solid #3CCACE;
+  }
+}
+
+.d-links {
+  font-size: 16px;
+  list-style: none;
+  li {
+    display: inline;
+    a{
+      color: #3CCACE;
+      text-decoration: none;
+    }
+  }
+  li:last-child {
+    float: right;
+  }
+}
+
+.d-relatedItems {
+  margin: 24px 0 8px 0;
+  font-size: 22px;
+  a {
+    text-decoration: none;
+    color: #3CCACE;
+  }
+}
+
+  
+
+.d-footer {
+  background-color: gray;
+  width: 100vw;
+  height: 400px;
+}

--- a/app/assets/stylesheets/_item_show.scss
+++ b/app/assets/stylesheets/_item_show.scss
@@ -14,10 +14,6 @@
   margin: 0 auto;
   width: 700px;
 }
-    
-.d-content {
-  // background-color: #ffffff;
-}
 
 .d-itemBox {
   padding: 24px 40px 40px;
@@ -39,6 +35,11 @@
         align-items: center;
         margin: 0 auto;
         flex-direction: column;
+        img {
+          width: 100%;
+          object-fit: cover;
+          height: 346px;
+        }
         ul {
           display: flex;
           justify-content: center;
@@ -46,6 +47,10 @@
           li {
             width: 25%;
             margin: 0 10px 0 0;
+            img {
+              object-fit: cover;
+              height: 87px;
+            }
           }
         }
       }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -19,4 +19,5 @@
  @import 'font-awesome-sprockets';
  @import 'font-awesome';
  @import 'item_new.scss';
+ @import 'item_show.scss';
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -8,6 +8,9 @@ class ItemsController < ApplicationController
     Item.create(item_params)
   end
   
+  def show
+  end
+  
   private
   def item_params
     params.require(:item).permit(:name, :descripton, :price, :buyer_id, :size, :condition, :wait, :postage, :category_id, :brand_id)

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -7,17 +7,16 @@
         .d-itemBox__name
           product1
         .d-itemBox__body
-          -# 画像のサイズの調整必要あり
           %ul
             %li
-              %image{:src => "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png"}
-                %ul
-                  %li
-                    %image{:src => "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", :width => "75", :height => "75"}
-                  %li
-                    %image{:src => "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/11/a005.png", :width => "75", :height => "75"}
-                  %li
-                    %image{:src => "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/12/a006.png", :width => "75", :height => "75"}
+              = image_tag  "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png"
+              %ul
+                %li
+                  = image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", :width => "75", :height => "75"
+                %li
+                  = image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/11/a005.png", :width => "75", :height => "75"
+                %li
+                  = image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/12/a006.png", :width => "75", :height => "75"
 
         .d-itemBox__price
           ¥10000

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -1,0 +1,102 @@
+.d-header
+  FURIMA ここはヘッダーです
+.d-main
+  .d-showMain
+    .d-content
+      .d-itemBox
+        .d-itemBox__name
+          product1
+        .d-itemBox__body
+          -# 画像のサイズの調整必要あり
+          %ul
+            %li
+              %image{:src => "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png"}
+                %ul
+                  %li
+                    %image{:src => "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", :width => "75", :height => "75"}
+                  %li
+                    %image{:src => "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/11/a005.png", :width => "75", :height => "75"}
+                  %li
+                    %image{:src => "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/12/a006.png", :width => "75", :height => "75"}
+
+        .d-itemBox__price
+          ¥10000
+          .d-itemBox__price-detail
+            %span (税込)
+            %span 送料込み
+        .d-itemDetail
+          .noticeMsg
+            %p
+              商品の紹介文商品の紹介文商品の紹介文商品の紹介文商品の紹介文商品の紹介文商品の紹介文商品の紹介文商品の紹介文
+        .d-table
+          %table
+            %tbody
+              %tr
+                %th hoge
+                 
+                %td hoge
+              %tr
+                %th カテゴリー
+                %td ベビー・キッズ
+              %tr
+                %th ブランド
+                %td hoge
+              %tr
+                %th 商品のサイズ
+                %td hoge
+              %tr
+                %th 商品の状態
+                %td hoge
+              %tr
+                %th 配送料の負担
+                %td hoge
+              %tr
+                %th 発送元の地域
+                %td hoge
+              %tr
+                %th 発送日の目安
+                %td hoge
+        .d-optonalArea
+          %ul
+            %li.d-optinalBtn.d-likeBtn
+              =icon('fa','star')
+              お気に入り 0
+          %ul.d-optional
+            %li.d-optionalBtn
+              %a{:href => "#"}
+                =icon('fa','flag')
+                不適切な商品の通報
+      .d-itemChangeBox
+        -# if文で分岐します
+        %ul.d-itemChangeBox__btnList
+          %li
+            %button.d-itemChangeBox__btnList__editBtn
+              商品の編集
+          or
+          %li.d-deleteBtn
+            %button
+              この商品を削除する
+      .d-commentBox
+        -# ここにはform_forなどが入る想定です
+        %textarea
+        .d-noticeMsg
+          %p
+            相手のことを考え丁寧なコメントを心がけましょう。
+            %br 不快な言葉遣いなどは利用制限や退会処分となることがあります。
+        %br
+        %button.d-commentBtn
+          =icon('fa','comment')
+          コメントする
+
+    %ur.d-links
+      %li 
+        =link_to "<前の商品"
+      %li 
+        =link_to "後ろの商品>"
+    .d-relatedItems
+      =link_to "カテゴリをもっと見る"
+      
+.d-footer
+  今すぐ無料ダウンロード
+  FURIMA
+  ここはフッターです

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   root 'posts#index'
   resources :users, only: :show
-  resources :items, only: [:new, :create]
+  resources :items, only: [:new, :create, :show]
 end


### PR DESCRIPTION
# What
- 商品詳細ページのビューを作成
- サーバーサイドの実装で変更する部分
-- 表のバリュー部分
--- @item.nameなどで変数をあてる予定。現在は文字をそのまま配置
-- コメント欄のフォーム
--- form_forなどを用いてコメントテーブルに保存されるようにする
-- コメントの表示
--- コメント機能実装時に追記する予定
-- 各ボタン
--- それぞれの機能が実装されたら遷移するようにリンクをあてる予定

- 加えてshowアクションの為のルーティングとコントローラを便宜的に編集した

# Why
- 商品詳細を確認する為に必要なビューファイルであるから。