### PR TITLE
background-imageの記述を変更

### DIFF
--- a/app/assets/stylesheets/_posts.scss
+++ b/app/assets/stylesheets/_posts.scss
@@ -106,7 +106,7 @@
     height: 560px;
     background-color: white;
     &__image{
-      background-image: url(bg-mainVisual-pict_pc.jpg);
+      background-image: image-url('bg-mainVisual-pict_pc.jpg');
       width: 100%;
       height: 560px;
       background-position: top center;
@@ -265,7 +265,8 @@
     background-size:cover;
     height: 400px;
     background-position: bottom right;
-    align-items: center;background-image: url(bg-topMiddleDl-pict.jpg);
+    align-items: center;
+    background-image: image-url('bg-topMiddleDl-pict.jpg');
     padding: 100px;
     &__sentence{
       color: #fff;
@@ -446,7 +447,7 @@
     }
   }
   .t__bottom{
-    background-image: url(bg-appBanner-pict.jpg);
+    background-image: image-url('bg-appBanner-pict.jpg');
     padding: 100px 40px;
     position: relative;
     background-size: cover;


### PR DESCRIPTION
# what
backlground-image:url(~の記述を本番環境に合わせてurlの部分をimage-urlに変更した

# why
本番環境に移行した際にassets/imageのファイルは全てpublic/imageに移されてdigestという仕組みでユニークな拡張子がつけられる為、urlの指定では呼び出せなくなる
その為、image-urlメソッドで移動の際に、拡張子を付与して呼び出せるようにした