### PR TITLE
ユーザーマイページ機能の追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Things you may want to cover:
 |first_name_kana|string|null: false|
 |nickname|string|null: :false|
 |e-mail|string|null: ：false|
-|number|integer|null: :false|
+|number|string|null: :false|
 |password|string|null: :false|
 |password_confirmation|string|null: :false|
 |gender|integer|null: :false|
@@ -110,7 +110,7 @@ add_index: [:user_id, :item_id]
 ## itemsテーブル
 |Column|Type|Options|
 |:------|:----|:-------|
-|user|string|foreign_key: true|
+|user_id|integer|foreign_key: true|
 |name|string|null:：false|
 |description|text|null: :false|
 |price|integer|null:：false|

--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -1,4 +1,18 @@
 class AddressesController < ApplicationController
   def edit
+    @user = User.find(params[:id])
+    @address = @user.address
+  end
+
+  def update
+    @user = User.find(params[:id])
+    @address = @user.address
+    @address.update(update_params)
+    sign_in(:user, @user)
+  end
+
+  private
+  def update_params
+    params.require(:address).permit(:family_name, :first_name, :family_name_kana, :first_name_kana, :postal_code, :city, :local, :block, :building, :number)
   end
 end

--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -1,11 +1,10 @@
 class AddressesController < ApplicationController
+  before_action :set_user_params, only: [:edit, :update]
   def edit
-    @user = User.find(params[:id])
     @address = @user.address
   end
 
   def update
-    @user = User.find(params[:id])
     @address = @user.address
     @address.update(update_params)
     sign_in(:user, @user)
@@ -14,5 +13,9 @@ class AddressesController < ApplicationController
   private
   def update_params
     params.require(:address).permit(:family_name, :first_name, :family_name_kana, :first_name_kana, :postal_code, :city, :local, :block, :building, :number)
+  end
+
+  def set_user_params
+    @user = User.find(params[:id])
   end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -71,6 +71,10 @@ class Users::RegistrationsController < Devise::RegistrationsController
   def address_params
     params.require(:address).permit(:family_name, :first_name, :family_name_kana, :first_name_kana, :postal_code, :city, :local, :block, :building, :number)
   end
+
+  def update_resource(resource, params)
+    resource.update_without_password(params)
+  end
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_account_update_params
   #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,22 +1,35 @@
 class UsersController < ApplicationController
 
-  before_action :set_user, only: :show
+  before_action :set_user_params, only: [:show, :edit, :update]
+  before_action :set_user_current, only: :index
 
   def index
-    @user = User.find(current_user.id)
   end
 
   def show
   end
 
+  def edit
+  end
+
+  def update
+    @user.update(update_params)
+    sign_in(:user, @user)
+  end
+
 
   private
-  def set_user
+  
+  def set_user_params
     @user = User.find(params[:id])
   end
 
-  def user_params
-    params.require(user).permit(:nickname, :email, :introduction, :password, :password_confirmation)
+  def set_user_current
+    @user = User.find(current_user.id)
+  end
+
+  def update_params
+    params.require(:user).permit(:nickname, :introduction, :password, :password_confirmation)
   end
 
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,19 +1,23 @@
 class UsersController < ApplicationController
 
-  before_action :set_user, only: [:index, :show, :edit]
+  before_action :set_user, only: :show
 
   def index
+    @user = User.find(current_user.id)
   end
 
   def show
   end
 
-  def edit
-  end
 
   private
   def set_user
     @user = User.find(params[:id])
   end
+
+  def user_params
+    params.require(user).permit(:nickname, :email, :introduction, :password, :password_confirmation)
+  end
+
 
 end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -11,4 +11,7 @@ class Address < ApplicationRecord
     message: "全角文字のみが使えます" }
   validates :family_name_kana,:first_name_kana, format: { with: /\A[ァ-ヶー－]+\z/,
     message: "全角カナのみが使えます" }
+
+  # 文字数制限
+  validates :postal_code, length: {in: 7..7}
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,6 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
-  has_many :items
 
   # バリデーション
   validates :nickname, :family_name, :first_name, :family_name_kana, :first_name_kana, :year, :month, :day, :number, :gender, :password_confirmation,  presence: true
@@ -15,6 +14,8 @@ class User < ApplicationRecord
   validates :family_name_kana,:first_name_kana, format: { with: /\A[ァ-ヶー－]+\z/,
     message: "全角カナのみが使えます" }
 
+  # アソシエーション
+  has_many :items
   has_one :address
   has_one :card
 end

--- a/app/views/addresses/edit.html.haml
+++ b/app/views/addresses/edit.html.haml
@@ -1,2 +1,47 @@
-%h1 Addresses#edit
-%p Find me in app/views/addresses/edit.html.haml
+%h2
+  プロフィールの変更
+  = render "devise/shared/error_messages", resource: @address
+= form_for @address do |f|
+  .field
+    = f.label :名字
+    %br/
+    = f.text_field :family_name, autofocus: true, autocomplete: "family_name"
+  .field
+    = f.label :名前
+    %br/
+    = f.text_field :first_name, autofocus: true, autocomplete: "first_name"
+  .field
+    = f.label :ミョウジ
+    %br/
+    = f.text_field :family_name_kana, autofocus: true, autocomplete: "family_name_kana"
+  .field
+    = f.label :ナマエ
+    %br/
+    = f.text_field :first_name_kana, autofocus: true, autocomplete: "first_name_kana"
+  .field
+    = f.label :郵便番号
+    %br/
+    = f.text_field :postal_code, autofocus: true, autocomplete: "postal_code"
+  .field
+    = f.label :都道府県
+    %br/
+    = f.text_field :city, autofocus: true, autocomplete: "city"
+  .field
+    = f.label :市町村
+    %br/
+    = f.text_field :local, autofocus: true, autocomplete: "local"
+  .field
+    = f.label :番地
+    %br/
+    = f.text_field :block, autofocus: true, autocomplete: "block"
+  .field
+    = f.label :マンション名
+    %br/
+    = f.text_field :building, autofocus: true, autocomplete: "building"
+  .field
+    = f.label :連絡先
+    %br/
+    = f.text_field :number, autofocus: true, autocomplete: "number"
+  .actions
+    = f.submit "Update"
+= link_to "戻る", users_path(@user.id)

--- a/app/views/addresses/edit.html.haml
+++ b/app/views/addresses/edit.html.haml
@@ -1,47 +1,46 @@
 %h2
   プロフィールの変更
-  = render "devise/shared/error_messages", resource: @address
 = form_for @address do |f|
   .field
-    = f.label :名字
+    = f.label "名字"
     %br/
     = f.text_field :family_name, autofocus: true, autocomplete: "family_name"
   .field
-    = f.label :名前
+    = f.label "名前"
     %br/
     = f.text_field :first_name, autofocus: true, autocomplete: "first_name"
   .field
-    = f.label :ミョウジ
+    = f.label "ミョウジ"
     %br/
     = f.text_field :family_name_kana, autofocus: true, autocomplete: "family_name_kana"
   .field
-    = f.label :ナマエ
+    = f.label "ナマエ"
     %br/
     = f.text_field :first_name_kana, autofocus: true, autocomplete: "first_name_kana"
   .field
-    = f.label :郵便番号
+    = f.label "郵便番号"
     %br/
     = f.text_field :postal_code, autofocus: true, autocomplete: "postal_code"
   .field
-    = f.label :都道府県
+    = f.label "都道府県"
     %br/
     = f.text_field :city, autofocus: true, autocomplete: "city"
   .field
-    = f.label :市町村
+    = f.label "市町村"
     %br/
     = f.text_field :local, autofocus: true, autocomplete: "local"
   .field
-    = f.label :番地
+    = f.label "番地"
     %br/
     = f.text_field :block, autofocus: true, autocomplete: "block"
   .field
-    = f.label :マンション名
+    = f.label "マンション名"
     %br/
     = f.text_field :building, autofocus: true, autocomplete: "building"
   .field
-    = f.label :連絡先
+    = f.label "連絡先"
     %br/
     = f.text_field :number, autofocus: true, autocomplete: "number"
   .actions
-    = f.submit "Update"
+    = f.submit "更新する"
 = link_to "戻る", users_path(@user.id)

--- a/app/views/addresses/update.html.haml
+++ b/app/views/addresses/update.html.haml
@@ -1,0 +1,8 @@
+= render partial: 'layouts/header', locals: { header: @header }
+.after-sign-up
+  .after-sign-up_content
+    .after-sign-up_content_box
+      %h1.after-sign-up_content_box_message 変更が完了しました
+      .after-sign-up_content_box_image
+      %p.after-sign-up_content_box_p 引き続きお買い物をお楽しみください
+= render partial: 'layouts/footer', locals: { footer: @footer }

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -1,5 +1,5 @@
 %h2
-  Edit #{resource_name.to_s.humanize}
+  ユーザー登録情報の変更
 = form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
   = render "devise/shared/error_messages", resource: resource
   .field
@@ -25,7 +25,4 @@
     = f.password_field :password_confirmation, autocomplete: "new-password"
   .actions
     = f.submit "Update"
-%h3 Cancel my account
-%p
-  Unhappy? #{button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete}
-= link_to "Back", :back
+= link_to "戻る", users_path(@user.id)

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -3,31 +3,26 @@
 = form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
   = render "devise/shared/error_messages", resource: resource
   .field
-    = f.label :email
+    = f.label :メールアドレス
     %br/
     = f.email_field :email, autofocus: true, autocomplete: "email"
   - if devise_mapping.confirmable? && resource.pending_reconfirmation?
     %div
       Currently waiting confirmation for: #{resource.unconfirmed_email}
   .field
-    = f.label :password
-    %i (leave blank if you don't want to change it)
+    = f.label :新しいパスワード
+    %i 
     %br/
     = f.password_field :password, autocomplete: "new-password"
     - if @minimum_password_length
       %br/
       %em
         = @minimum_password_length
-        characters minimum
+        文字以上
   .field
-    = f.label :password_confirmation
+    = f.label :新しいパスワード（確認用）
     %br/
     = f.password_field :password_confirmation, autocomplete: "new-password"
-  .field
-    = f.label :current_password
-    %i (we need your current password to confirm your changes)
-    %br/
-    = f.password_field :current_password, autocomplete: "current-password"
   .actions
     = f.submit "Update"
 %h3 Cancel my account

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -3,14 +3,14 @@
 = form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
   = render "devise/shared/error_messages", resource: resource
   .field
-    = f.label :メールアドレス
+    = f.label "メールアドレス"
     %br/
     = f.email_field :email, autofocus: true, autocomplete: "email"
   - if devise_mapping.confirmable? && resource.pending_reconfirmation?
     %div
       Currently waiting confirmation for: #{resource.unconfirmed_email}
   .field
-    = f.label :新しいパスワード
+    = f.label "新しいパスワード"
     %i 
     %br/
     = f.password_field :password, autocomplete: "new-password"
@@ -20,7 +20,7 @@
         = @minimum_password_length
         文字以上
   .field
-    = f.label :新しいパスワード（確認用）
+    = f.label "新しいパスワード（確認用）"
     %br/
     = f.password_field :password_confirmation, autocomplete: "new-password"
   .actions

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -25,4 +25,4 @@
     = f.password_field :password_confirmation, autocomplete: "new-password"
   .actions
     = f.submit "Update"
-= link_to "戻る", users_path(@user.id)
+= link_to "戻る", :back

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,64 +1,63 @@
-%h2 Sign up
+%h2 会員情報登録
 = form_for(@user, url: registration_path(resource_name)) do |f|
   = devise_error_messages
   .field
-    = f.label :nickname
+    = f.label "ニックネーム"
     %br/
     = f.text_field :nickname, autofocus: true, autocomplete: "nickname"
   .field
-    = f.label :email
+    = f.label "Eメールアドレス"
     %br/
     = f.email_field :email, autofocus: true, autocomplete: "email"
   .field
-    = f.label :password
+    = f.label "パスワード"
     - if @minimum_password_length
       %em
         (7 characters minimum)
     %br/
     = f.password_field :password, autocomplete: "new-password"
   .field
-    = f.label :password_confirmation
+    = f.label "パスワード（確認用）"
     - if @minimum_password_length
       %em
         (7 characters minimum)
     %br/
     = f.password_field :password_confirmation, autocomplete: "password_confirmation"
   .field
-    = f.label :family_name
+    = f.label "名字"
     %br/
     = f.text_field :family_name, autofocus: true, autocomplete: "family_name"
   .field
-    = f.label :first_name
+    = f.label "名前"
     %br/
     = f.text_field :first_name, autofocus: true, autocomplete: "first_name"
   .field
-    = f.label :family_name_kana
+    = f.label "ミョウジ"
     %br/
     = f.text_field :family_name_kana, autofocus: true, autocomplete: "family_name_kana"
   .field
-    = f.label :first_name_kana
+    = f.label "ナマエ"
     %br/
     = f.text_field :first_name_kana, autofocus: true, autocomplete: "first_name_kana"
   .field
-    = f.label :year
+    = f.label "年"
     %br/
     = f.text_field :year, autofocus: true, autocomplete: "year"
   .field
-    = f.label :month
+    = f.label "月"
     %br/
     = f.text_field :month, autofocus: true, autocomplete: "month"
   .field
-    = f.label :day
+    = f.label "日"
     %br/
     = f.text_field :day, autofocus: true, autocomplete: "day"
   .field
-    = f.label :number
+    = f.label "電話番号"
     %br/
     = f.text_field :number, autofocus: true, autocomplete: "number"
   .field
-    = f.label :gender
+    = f.label "性別"
     %br/
     = f.text_field :gender, autofocus: true, autocomplete: "gender"
   .actions
-    = f.submit "Sign up"
-= render "devise/shared/links"
+    = f.submit "住所登録画面へ"

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -58,6 +58,11 @@
   .field
     = f.label "性別"
     %br/
-    = f.text_field :gender, autofocus: true, autocomplete: "gender"
-  .actions
+    = f.radio_button :gender, 1 
+    男性
+    = f.radio_button :gender, 2
+    女性
+    = f.radio_button :gender, 3
+    未選択
+  .actions 
     = f.submit "住所登録画面へ"

--- a/app/views/devise/registrations/new_address.html.haml
+++ b/app/views/devise/registrations/new_address.html.haml
@@ -1,46 +1,45 @@
-%h2 Sign up
+%h2 住所登録
 = form_for @address do |f|
   = render "devise/shared/error_messages", resource: @address
   .field
-    = f.label :family_name
+    = f.label "名字"
     %br/
     = f.text_field :family_name, autofocus: true, autocomplete: "family_name"
   .field
-    = f.label :first_name
+    = f.label "名前"
     %br/
     = f.text_field :first_name, autofocus: true, autocomplete: "first_name"
   .field
-    = f.label :family_name_kana
+    = f.label "ミョウジ"
     %br/
     = f.text_field :family_name_kana, autofocus: true, autocomplete: "family_name_kana"
   .field
-    = f.label :first_name_kana	
+    = f.label "ナマエ"
     %br/
-    = f.text_field :first_name_kana	, autofocus: true, autocomplete: "first_name_kana"
+    = f.text_field :first_name_kana, autofocus: true, autocomplete: "first_name_kana"
   .field
-    = f.label :postal_code	
+    = f.label "郵便番号"
     %br/
-    = f.text_field :postal_code	, autofocus: true, autocomplete: "postal_code"
+    = f.text_field :postal_code, autofocus: true, autocomplete: "postal_code"
   .field
-    = f.label :city
+    = f.label "都道府県"
     %br/
     = f.text_field :city, autofocus: true, autocomplete: "city"
   .field
-    = f.label :local
+    = f.label "市町村"
     %br/
     = f.text_field :local, autofocus: true, autocomplete: "local"
   .field
-    = f.label :block
+    = f.label "番地"
     %br/
     = f.text_field :block, autofocus: true, autocomplete: "block"
   .field
-    = f.label :building
+    = f.label "マンション名"
     %br/
     = f.text_field :building, autofocus: true, autocomplete: "building"
   .field
-    = f.label :number
+    = f.label "連絡先"
     %br/
     = f.text_field :number, autofocus: true, autocomplete: "number"
   .actions
-    = f.submit "Sign up"
-= render "devise/shared/links"
+    = f.submit "登録"

--- a/app/views/devise/registrations/update.html.haml
+++ b/app/views/devise/registrations/update.html.haml
@@ -1,0 +1,8 @@
+= render partial: 'layouts/header', locals: { header: @header }
+.after-sign-up
+  .after-sign-up_content
+    .after-sign-up_content_box
+      %h1.after-sign-up_content_box_message 変更が完了しました
+      .after-sign-up_content_box_image
+      %p.after-sign-up_content_box_p 引き続きお買い物をお楽しみください
+= render partial: 'layouts/footer', locals: { footer: @footer }

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -1,0 +1,28 @@
+%h2
+  プロフィールの変更
+= form_for @user do |f|
+  .field
+    = f.label :nickname, "ニックネーム"
+    %br/
+    = f.text_field :nickname, autofocus: true, autocomplete: "nickname"
+  .field
+    = f.label :introduction, "自己紹介"
+    %br/
+    = f.text_area :introduction, autofocus: true, autocomplete: "introduction"
+  .field
+    = f.label :パスワード
+    - if @minimum_password_length
+      %em
+        (7 characters minimum)
+    %br/
+    = f.password_field :password, autocomplete: "new-password"
+  .field
+    = f.label :パスワード（確認用）
+    - if @minimum_password_length
+      %em
+        (7 characters minimum)
+    %br/
+    = f.password_field :password_confirmation, autocomplete: "password_confirmation"
+  .actions
+    = f.submit "Update"
+= link_to "戻る", users_path(@user.id)

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -2,27 +2,27 @@
   プロフィールの変更
 = form_for @user do |f|
   .field
-    = f.label :nickname, "ニックネーム"
+    = f.label "ニックネーム"
     %br/
     = f.text_field :nickname, autofocus: true, autocomplete: "nickname"
   .field
-    = f.label :introduction, "自己紹介"
+    = f.label "自己紹介"
     %br/
     = f.text_area :introduction, autofocus: true, autocomplete: "introduction"
   .field
-    = f.label :パスワード
+    = f.label "パスワード"
     - if @minimum_password_length
       %em
         (7 characters minimum)
     %br/
     = f.password_field :password, autocomplete: "new-password"
   .field
-    = f.label :パスワード（確認用）
+    = f.label "パスワード（確認用）"
     - if @minimum_password_length
       %em
         (7 characters minimum)
     %br/
     = f.password_field :password_confirmation, autocomplete: "password_confirmation"
   .actions
-    = f.submit "Update"
+    = f.submit "更新する"
 = link_to "戻る", :back

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -25,4 +25,4 @@
     = f.password_field :password_confirmation, autocomplete: "password_confirmation"
   .actions
     = f.submit "Update"
-= link_to "戻る", users_path(@user.id)
+= link_to "戻る", :back

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -1,5 +1,5 @@
-= link_to edit_user_path(current_user.id)  do
-  ユーザー情報の変更
+= link_to edit_user_registration_path(current_user.id)  do
+  ユーザー登録情報の変更
 = link_to edit_address_path(current_user.id)  do
   配送先情報の変更
 - if @user.card.present?

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -1,5 +1,7 @@
 = link_to edit_user_registration_path(current_user.id)  do
   ユーザー登録情報の変更
+= link_to edit_user_path(current_user.id)  do
+  プロフィールの変更
 = link_to edit_address_path(current_user.id)  do
   配送先情報の変更
 - if @user.card.present?

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -30,11 +30,7 @@
           .u_detail_review-box_each_bad_number 0
       .u_detail_content
         %p.u_detail_content_comment
-          ここに自己紹介文がはいります
-          %br
-          こんなかんじ
-          %br
-          実際にはデータベースから値をとるのでbrタグは使いません
+          = simple_format @user.introduction
     .u_sns
       %ul.u_sns-box
         %li.u_sns-box_facebook

--- a/app/views/users/update.html.haml
+++ b/app/views/users/update.html.haml
@@ -1,0 +1,8 @@
+= render partial: 'layouts/header', locals: { header: @header }
+.after-sign-up
+  .after-sign-up_content
+    .after-sign-up_content_box
+      %h1.after-sign-up_content_box_message 変更が完了しました
+      .after-sign-up_content_box_image
+      %p.after-sign-up_content_box_p 引き続きお買い物をお楽しみください
+= render partial: 'layouts/footer', locals: { footer: @footer }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
   root 'posts#index'
   resources :users,     only: [:show, :index, :edit, :update]
   resources :items
-  resources :addresses, only: [:edit]
+  resources :addresses, only: [:edit, :update]
   resources :cards, only: [:new, :edit]
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
     post 'addresses', to: 'users/registrations#create_address'
   end
   root 'posts#index'
-  resources :users,     only: [:show, :index, :edit]
+  resources :users,     only: [:show, :index, :edit, :update]
   resources :items
   resources :addresses, only: [:edit]
   resources :cards, only: [:new, :edit]


### PR DESCRIPTION
# what
ユーザー登録情報、プロフィール、住所をユーザーページから変更できるようにした
新規登録での性別をradio形式に変更
# why
ユーザーが引越しやメールアドレスの変更をしても大丈夫なように機能追加
従来の形式だとユーザーが性別を登録するさいに困るから