### PR TITLE
商品一覧機能の実装

### DIFF
--- a/app/assets/stylesheets/_item_index.scss
+++ b/app/assets/stylesheets/_item_index.scss
@@ -94,7 +94,6 @@
             font-weight: bold;
             font-size: 17px;
           }
-          // .exhibition-image {}
         }
         &__info {
           padding: 16px;

--- a/app/assets/stylesheets/_item_index.scss
+++ b/app/assets/stylesheets/_item_index.scss
@@ -52,28 +52,73 @@
       font-weight: bold;
       text-align: center;
       font-size: 25px;
-      padding: 5px;
+      padding: 30px 0 15px;
     }
   &__container {
-    width: 100%;
+    width: 1200px;
+    margin: 0 auto;
+    padding-bottom: 20px;
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;
-    justify-content: center;
-    &__content {
-      height: 300px;
-      width: 190px;
-      margin: 10px;
-      border-radius: 2px;
-      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.22);
-      border-top: solid 2px #5d627b;
-      &__image {
-        margin: 2px;
-        height: 200px;
-        // .exhibition-image {}
+    
+    &__border {
+      margin-right: 20px;
+      &__content {
+        background-color: #ffffff;
+        height: 330px;
+        width: 220px;
+        margin-top: 20px;
+        border-radius: 2px;
+        box-shadow: 0 1px 2px rgba(0, 0, 0, 0.22);
+        &__image {
+          img {
+            width: 100%;
+          }
+          margin: 2px;
+          // height: 200px;
+          position: relative;
+          &--triangle {
+            position: absolute;
+            top: 0;
+            left: 0px;
+            border-bottom: 75px solid transparent;
+            border-left: 75px solid red;
+          }
+          &__soldout {
+            transform: rotate(-45deg);
+            position: absolute;
+            top: 14px;
+            left: 2px;
+            color: #ffffff;
+            font-weight: bold;
+            font-size: 17px;
+          }
+          // .exhibition-image {}
+        }
+        &__info {
+          padding: 16px;
+          &__name {
+            word-break: break-all;
+            height: 48px;
+          }
+          &__price {
+            word-break: break-all;
+            font-size: 16px;
+            font-weight: 600;
+            color: #333;
+            text-decoration: none;
+            margin-top: 8px;
+            line-height: 16px;
+            .fa-heart {
+              float: right;
+              color: #ccc;
+            }
+          }
+        }
       }
-      &__name {
-        padding: 10px 10px;
+      &__content:hover{
+        border: solid 1px #3CCACE;
       }
     }
   }

--- a/app/assets/stylesheets/_posts.scss
+++ b/app/assets/stylesheets/_posts.scss
@@ -408,41 +408,51 @@
       font-weight: bold;
       color: #333;
     }
-    &__new{
-      font-weight: bold;
+    font-weight: bold;
       h3{
         color: #3CCACE;
         font-size: 24px;
         text-align: center;
         font-weight: bold;
-      }
-      &--item{
-        width: 780px;
-        margin: 26px auto 0;
+        }
+    &__index {
+      // width: 740px;
+      margin: 0 auto;
+      &__new{
         display: flex;
-        justify-content: space-around;
-        background-color: #3CCACE;
-        &--image{
-          width: 220px;
-          position: relative;
-          height: 150px;
-          overflow: hidden;
-          margin: 0;
-          z-index: auto;
-          .simpson{
-            top: 0;
-            left: 0;
-            right: 0;
-            bottom: 0;
-            width: 100%;
-            z-index: auto;
+        justify-content: center;
+        &--item{
+          width: 780px;
+          margin: 26px auto 0;
+          display: flex;
+          justify-content: space-around;
+          background-color: #3CCACE;
+          &--image{
+            width: 220px;
+            position: relative;
             height: 150px;
-          }
-          .t__pickup__new__item--name{
-            background-color: #fff;
-            color: #333;
+            overflow: hidden;
+            margin: 0;
+            z-index: auto;
+            .simpson{
+              top: 0;
+              left: 0;
+              right: 0;
+              bottom: 0;
+              width: 100%;
+              z-index: auto;
+              height: 150px;
+            }
+            .t__pickup__new__item--name{
+              background-color: #fff;
+              color: #333;
+            }
           }
         }
+      }
+      &__more {
+        float: right;
+        color: #3CCACE;
       }
     }
   }

--- a/app/assets/stylesheets/_posts.scss
+++ b/app/assets/stylesheets/_posts.scss
@@ -416,7 +416,6 @@
         font-weight: bold;
         }
     &__index {
-      // width: 740px;
       margin: 0 auto;
       &__new{
         display: flex;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :set_item, only: [:update, :edit, :destroy]
-  before_action :move_to_root, except: [:index, :show]
+  before_action :move_to_root, except: [:index, :show, :top]
   def index
     @items = Item.includes(:images).order('created_at DESC')
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -48,7 +48,10 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
     @comment = Comment.new
     @comments = @item.comments.includes(:user)
+  end
 
+  def top
+    @items = Item.includes(:images).order('created_at DESC').limit(3)
   end
   
   private

--- a/app/views/items/_item.html.haml
+++ b/app/views/items/_item.html.haml
@@ -1,6 +1,17 @@
-.e__middle__container__content
-  .e__middle__container__content__image
-    = image_tag item.images[0].src.url
-  .e__middle__container__content__name
-    = link_to item.name, item_path(item.id)
-      
+= link_to item_path(item.id) do
+  .e__middle__container__border
+    .e__middle__container__border__content
+      .e__middle__container__border__content__image
+        = image_tag item.images[0].src.url
+        -if item.buyer_id.present?
+          .e__middle__container__border__content__image--triangle
+          .e__middle__container__border__content__image__soldout
+            SOLD
+      .e__middle__container__border__content__info
+        .e__middle__container__border__content__info__name
+          = item.name
+        .e__middle__container__border__content__info__price
+          ¥
+          = item.price
+          =icon('far','heart') do
+            %span 100

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -15,10 +15,14 @@
             
 .e__middle
   .e__middle__title
-    %h1 新着アイテム
+    %h1 新着アイテム一覧
   .e__middle__container
     = render @items
-      
+= render partial: 'layouts/footer', locals: { footer: @footer }
+%a(href="/items/new")
+  .sellBtn
+    %span.sellBtn__text 出品する
+    = image_tag 'icon_camera.png', alt: '', height: '', width: '', class: 'sellBtn__icon'
           
         
       

--- a/app/views/items/top.html.haml
+++ b/app/views/items/top.html.haml
@@ -85,48 +85,19 @@
 .t__pickup
   .t__pickup__category
     %h2 ピックアップカテゴリー
-  .t__pickup__new
     %h3 新規投稿商品
-     
-    -# .t__pickup__new--item
-    -#   .u_item-box_container_item
-    -#     = link_to "#",class:".u_item-box_container_item_link" do
-    -#       %figure.u_item-box_container_item_link-box
-    -#         = image_tag "pict-reason-02.jpg", class: "u_item-box_container_item_link-box_image"
-    -#       .u_item-box_container_item_link_body
-    -#         %h3.u_item-box_container_item_link_body-name スマホと手のセット
-    -#         .u_item-box_container_item_link_body_under
-    -#           .u_item-box_container_item_link_body_under-price ￥99,999
-    -#           .u_item-box_container_item_link_body_under-favorite
-    -#             %i.far.fa-heart.u_item-box_container_item_link_body_under-favorite_icon
-    -#             %span.u_item-box_container_item_link_body_under-favorite_number 12
-    -#   .u_item-box_container_item
-    -#     = link_to "#",class:".u_item-box_container_item_link" do
-    -#       %figure.u_item-box_container_item_link-box
-    -#         = image_tag "pict-reason-02.jpg", class: "u_item-box_container_item_link-box_image"
-    -#       .u_item-box_container_item_link_body
-    -#         %h3.u_item-box_container_item_link_body-name スマホと手のセット
-    -#         .u_item-box_container_item_link_body_under
-    -#           .u_item-box_container_item_link_body_under-price ￥99,999
-    -#           .u_item-box_container_item_link_body_under-favorite
-    -#             %i.far.fa-heart.u_item-box_container_item_link_body_under-favorite_icon
-    -#             %span.u_item-box_container_item_link_body_under-favorite_number 12
-    -#   .u_item-box_container_item
-    -#     = link_to "#",class:".u_item-box_container_item_link" do
-    -#       %figure.u_item-box_container_item_link-box
-    -#         = image_tag "pict-reason-02.jpg", class: "u_item-box_container_item_link-box_image"
-    -#       .u_item-box_container_item_link_body
-    -#         %h3.u_item-box_container_item_link_body-name スマホと手のセット
-    -#         .u_item-box_container_item_link_body_under
-    -#           .u_item-box_container_item_link_body_under-price ￥99,999
-    -#           .u_item-box_container_item_link_body_under-favorite
-    -#             %i.far.fa-heart.u_item-box_container_item_link_body_under-favorite_icon
-    -#             %span.u_item-box_container_item_link_body_under-favorite_number 12
+  .t__pickup__index
+    .t__pickup__index__new
+      =render @items
+    .t__pickup__index__more
+      = link_to 'もっと見る>',items_path
 .t__pickup
   .t__pickup__category
     %h2 ピックアップブランド
-  .t__pickup__new
     %h3 アーカイバ
+    
+  .t__pickup__new
+    
     .t__pickup__new--item
       .u_item-box_container_item
         = link_to "#",class:".u_item-box_container_item_link" do

--- a/app/views/items/top.html.haml
+++ b/app/views/items/top.html.haml
@@ -10,10 +10,10 @@
           フリマアプリです
       .t__center__image__content-icon
         .t__center__image__content-icon-app
-          %a(id="aBtn" href="http://google.co.jp")
+          =link_to "http://google.co.jp", id: 'aBtn' do
             = image_tag 'apple-icon.png', alt: '', class: 'apple'
         .t__center__image__content-icon-google
-          %a(id="gBtn" href="http://google.co.jp")
+          =link_to "http://google.co.jp", id: 'gBtn' do
             = image_tag 'google-play.png', alt: '', class: 'google'
 
 .t__center__middle
@@ -54,10 +54,10 @@
         ほしかったあの商品に出会えるかもしれません。
   .t__center__middle__image-icon
     .t__center__middle-icon-app
-      %a(id="aBtn" href="http://google.co.jp")
+      =link_to "http://google.co.jp", id: 'aBtn' do
         = image_tag 'apple-icon.png', alt: '', class: 'apple'
     .t__center__middle-icon-google
-      %a(id="gBtn" href="http://google.co.jp")
+      =link_to "http://google.co.jp", id: 'gBtn' do
         = image_tag 'google-play.png', alt: '', class: 'google'
 .t__center__bottom
   .t__center__bottom__title 
@@ -97,51 +97,51 @@
     %h3 アーカイバ
     
   .t__pickup__new
-    
-    .t__pickup__new--item
-      .u_item-box_container_item
-        = link_to "#",class:".u_item-box_container_item_link" do
-          %figure.u_item-box_container_item_link-box
-            = image_tag "pict-reason-02.jpg", class: "u_item-box_container_item_link-box_image"
-          .u_item-box_container_item_link_body
-            %h3.u_item-box_container_item_link_body-name スマホと手のセット
-            .u_item-box_container_item_link_body_under
-              .u_item-box_container_item_link_body_under-price ￥99,999
-              .u_item-box_container_item_link_body_under-favorite
-                %i.far.fa-heart.u_item-box_container_item_link_body_under-favorite_icon
-                %span.u_item-box_container_item_link_body_under-favorite_number 12
-      .u_item-box_container_item
-        = link_to "#",class:".u_item-box_container_item_link" do
-          %figure.u_item-box_container_item_link-box
-            = image_tag "pict-reason-02.jpg", class: "u_item-box_container_item_link-box_image"
-          .u_item-box_container_item_link_body
-            %h3.u_item-box_container_item_link_body-name スマホと手のセット
-            .u_item-box_container_item_link_body_under
-              .u_item-box_container_item_link_body_under-price ￥99,999
-              .u_item-box_container_item_link_body_under-favorite
-                %i.far.fa-heart.u_item-box_container_item_link_body_under-favorite_icon
-                %span.u_item-box_container_item_link_body_under-favorite_number 12
-      .u_item-box_container_item
-        = link_to "#",class:".u_item-box_container_item_link" do
-          %figure.u_item-box_container_item_link-box
-            = image_tag "pict-reason-02.jpg", class: "u_item-box_container_item_link-box_image"
-          .u_item-box_container_item_link_body
-            %h3.u_item-box_container_item_link_body-name スマホと手のセット
-            .u_item-box_container_item_link_body_under
-              .u_item-box_container_item_link_body_under-price ￥99,999
-              .u_item-box_container_item_link_body_under-favorite
-                %i.far.fa-heart.u_item-box_container_item_link_body_under-favorite_icon
-                %span.u_item-box_container_item_link_body_under-favorite_number 12
+    -# 雛形として使用の可能性
+    -# .t__pickup__new--item
+    -#   .u_item-box_container_item
+    -#     = link_to "#",class:".u_item-box_container_item_link" do
+    -#       %figure.u_item-box_container_item_link-box
+    -#         = image_tag "pict-reason-02.jpg", class: "u_item-box_container_item_link-box_image"
+    -#       .u_item-box_container_item_link_body
+    -#         %h3.u_item-box_container_item_link_body-name スマホと手のセット
+    -#         .u_item-box_container_item_link_body_under
+    -#           .u_item-box_container_item_link_body_under-price ￥99,999
+    -#           .u_item-box_container_item_link_body_under-favorite
+    -#             %i.far.fa-heart.u_item-box_container_item_link_body_under-favorite_icon
+    -#             %span.u_item-box_container_item_link_body_under-favorite_number 12
+    -#   .u_item-box_container_item
+    -#     = link_to "#",class:".u_item-box_container_item_link" do
+    -#       %figure.u_item-box_container_item_link-box
+    -#         = image_tag "pict-reason-02.jpg", class: "u_item-box_container_item_link-box_image"
+    -#       .u_item-box_container_item_link_body
+    -#         %h3.u_item-box_container_item_link_body-name スマホと手のセット
+    -#         .u_item-box_container_item_link_body_under
+    -#           .u_item-box_container_item_link_body_under-price ￥99,999
+    -#           .u_item-box_container_item_link_body_under-favorite
+    -#             %i.far.fa-heart.u_item-box_container_item_link_body_under-favorite_icon
+    -#             %span.u_item-box_container_item_link_body_under-favorite_number 12
+    -#   .u_item-box_container_item
+    -#     = link_to "#",class:".u_item-box_container_item_link" do
+    -#       %figure.u_item-box_container_item_link-box
+    -#         = image_tag "pict-reason-02.jpg", class: "u_item-box_container_item_link-box_image"
+    -#       .u_item-box_container_item_link_body
+    -#         %h3.u_item-box_container_item_link_body-name スマホと手のセット
+    -#         .u_item-box_container_item_link_body_under
+    -#           .u_item-box_container_item_link_body_under-price ￥99,999
+    -#           .u_item-box_container_item_link_body_under-favorite
+    -#             %i.far.fa-heart.u_item-box_container_item_link_body_under-favorite_icon
+    -#             %span.u_item-box_container_item_link_body_under-favorite_number 12
 .t__bottom
   .t__bottom__innner
     %h2.t__bottom__innner__title だれでもかんたん、人生を変えるフリマアプリ
     %p.t__bottom__innner__text 今すぐ無料ダウンロード！
     .t__bottom__innner__icon
       .t__bottom__innner__icon-app
-        %a(id="aBtn" href="http://google.co.jp")
+        =link_to "http://google.co.jp", id: 'aBtn' do
           = image_tag 'apple-icon.png', alt: '', class: 'apple'
       .t__bottom__innner__icon-google
-        %a(id="gBtn" href="http://google.co.jp")
+        =link_to "http://google.co.jp", id: 'gBtn' do
           = image_tag 'google-play.png', alt: '', class: 'google'
 = render partial: 'layouts/footer', locals: { footer: @footer }
 %a(href="/items/new")

--- a/app/views/posts/index.html.haml
+++ b/app/views/posts/index.html.haml
@@ -87,41 +87,6 @@
     %h2 ピックアップカテゴリー
   .t__pickup__new
     %h3 新規投稿商品
-     
-    -# .t__pickup__new--item
-    -#   .u_item-box_container_item
-    -#     = link_to "#",class:".u_item-box_container_item_link" do
-    -#       %figure.u_item-box_container_item_link-box
-    -#         = image_tag "pict-reason-02.jpg", class: "u_item-box_container_item_link-box_image"
-    -#       .u_item-box_container_item_link_body
-    -#         %h3.u_item-box_container_item_link_body-name スマホと手のセット
-    -#         .u_item-box_container_item_link_body_under
-    -#           .u_item-box_container_item_link_body_under-price ￥99,999
-    -#           .u_item-box_container_item_link_body_under-favorite
-    -#             %i.far.fa-heart.u_item-box_container_item_link_body_under-favorite_icon
-    -#             %span.u_item-box_container_item_link_body_under-favorite_number 12
-    -#   .u_item-box_container_item
-    -#     = link_to "#",class:".u_item-box_container_item_link" do
-    -#       %figure.u_item-box_container_item_link-box
-    -#         = image_tag "pict-reason-02.jpg", class: "u_item-box_container_item_link-box_image"
-    -#       .u_item-box_container_item_link_body
-    -#         %h3.u_item-box_container_item_link_body-name スマホと手のセット
-    -#         .u_item-box_container_item_link_body_under
-    -#           .u_item-box_container_item_link_body_under-price ￥99,999
-    -#           .u_item-box_container_item_link_body_under-favorite
-    -#             %i.far.fa-heart.u_item-box_container_item_link_body_under-favorite_icon
-    -#             %span.u_item-box_container_item_link_body_under-favorite_number 12
-    -#   .u_item-box_container_item
-    -#     = link_to "#",class:".u_item-box_container_item_link" do
-    -#       %figure.u_item-box_container_item_link-box
-    -#         = image_tag "pict-reason-02.jpg", class: "u_item-box_container_item_link-box_image"
-    -#       .u_item-box_container_item_link_body
-    -#         %h3.u_item-box_container_item_link_body-name スマホと手のセット
-    -#         .u_item-box_container_item_link_body_under
-    -#           .u_item-box_container_item_link_body_under-price ￥99,999
-    -#           .u_item-box_container_item_link_body_under-favorite
-    -#             %i.far.fa-heart.u_item-box_container_item_link_body_under-favorite_icon
-    -#             %span.u_item-box_container_item_link_body_under-favorite_number 12
 .t__pickup
   .t__pickup__category
     %h2 ピックアップブランド

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,10 +7,11 @@ Rails.application.routes.draw do
     get 'addresses', to: 'users/registrations#new_address'
     post 'addresses', to: 'users/registrations#create_address'
   end
-  root 'posts#index'
+  root 'items#top'
 
   resources :users,     only: [:show, :index, :edit, :update]
   resources :items do
+    get 'top', to: 'items#top'
     resources :comments, only: :create
   end
   resources :addresses, only: [:edit, :update]


### PR DESCRIPTION
# What
- 新着商品の一覧を表示
- トップページを変更、新着のうち最新３件を表示
itemコントローラにtopアクションを実装
# Why
- ユーザーが選ぶ商品を表示させるため。
-----------------------------------------------------
現状、新着商品の一覧の表示を実装。
カテゴリ別、ブランド別の一覧機能は開発状況によります。