### PR TITLE
ページネーションの実装・前後レコードの取得の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,3 +70,5 @@ gem 'pry-rails'
 gem 'active_hash'
 gem 'payjp'
 gem 'dotenv-rails'
+
+gem 'kaminari'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,6 +147,18 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    kaminari (1.2.0)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.0)
+      kaminari-activerecord (= 1.2.0)
+      kaminari-core (= 1.2.0)
+    kaminari-actionview (1.2.0)
+      actionview
+      kaminari-core (= 1.2.0)
+    kaminari-activerecord (1.2.0)
+      activerecord
+      kaminari-core (= 1.2.0)
+    kaminari-core (1.2.0)
     kgio (2.11.3)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -303,6 +315,7 @@ DEPENDENCIES
   haml-rails
   jbuilder (~> 2.5)
   jquery-rails
+  kaminari
   listen (~> 3.0.5)
   mysql2 (>= 0.3.18, < 0.6.0)
   payjp

--- a/app/assets/stylesheets/_item_index.scss
+++ b/app/assets/stylesheets/_item_index.scss
@@ -121,4 +121,11 @@
       }
     }
   }
+  &__page {
+    color: #3CCACE;
+    text-align: center;
+    font-size: 18px;
+    font-weight: bold;
+    margin-bottom: 10px;
+  }
 }

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :set_item, only: [:update, :edit, :destroy]
   before_action :move_to_root, except: [:index, :show, :top]
   def index
-    @items = Item.includes(:images).order('created_at DESC')
+    @items = Item.includes(:images).order('created_at DESC').page(params[:page]).per(5)
   end
   
   def new
@@ -64,6 +64,4 @@ class ItemsController < ApplicationController
   def move_to_root
     redirect_to root_path unless user_signed_in?
   end
-
-  
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -11,4 +11,13 @@ class Item < ApplicationRecord
   belongs_to_active_hash :prefecture
   belongs_to_active_hash :category
   belongs_to_active_hash :brand
+
+  def previous
+    Item.where("id < ?", self.id).order("id DESC").first
+  end
+
+  def next
+    Item.where("id > ?", self.id).order("id ASC").first
+  end
+  
 end

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -18,6 +18,8 @@
     %h1 新着アイテム一覧
   .e__middle__container
     = render @items
+  .e__middle__page
+    = paginate(@items)
 = render partial: 'layouts/footer', locals: { footer: @footer }
 %a(href="/items/new")
   .sellBtn

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -132,9 +132,15 @@
 
     %ur.d-links
       %li 
-        =link_to "<前の商品"
+        - if @item.next.present?
+          = link_to item_path(@item.next) do
+            <
+            = @item.next.name
       %li 
-        =link_to "後ろの商品>"
+        - if @item.previous.present?
+          = link_to item_path(@item.previous) do
+            = @item.previous.name
+            >
     .d-relatedItems
       =link_to "カテゴリをもっと見る"
       

--- a/config/locales/kaminari_ja.yml
+++ b/config/locales/kaminari_ja.yml
@@ -1,0 +1,17 @@
+ja:
+  views:
+    pagination:
+      first: "&laquo; 最初"
+      last: "最後 &raquo;"
+      previous: "&lsaquo; 前"
+      next: "次 &rsaquo;"
+      truncate: "..."
+  helpers:
+    page_entries_info:
+      one_page:
+        display_entries:
+          zero: ""
+          one: "<strong>1-1</strong>/1件中"
+          other: "<strong>1-%{count}</strong>/%{count}件中"
+      more_pages:
+        display_entries: "<strong>%{first}-%{last}</strong>/%{total}件中"


### PR DESCRIPTION
# What
- gem 'kaminari'実装
新着商品一覧ページにてページネーションを実装
**最大５件で次ページにいく仕様だが多くする予定**
**メルカリは132件で次ページ**
- 新着商品の前後に移動できるリンクを実装
**ユーザー別、カテゴリ別などでも実装できそう**
# Why
- ページ遷移のUIを向上させるため。
---------------------------------------------------------
参考リンク
https://qiita.com/hrtkmztn/items/df09584cfc621699532c
https://easyramble.com/active-record-prev-next.html
https://www.for-engineer.life/entry/get-record/
関連リンク
https://railsguides.jp/active_record_querying.html