### PR TITLE
headerカテゴリ表示の分岐表示（見た目）

### DIFF
--- a/app/assets/stylesheets/_category.scss
+++ b/app/assets/stylesheets/_category.scss
@@ -1,0 +1,112 @@
+.categoryBtn,.brandBtn {
+  text-decoration: none;
+  color: black;
+}
+
+.categoryBtn:hover,.brandBtn:hover{
+  background-position: -100% 0;
+  color: orange;
+}
+
+.item-link{
+  color: black;
+  text-decoration: none;
+  line-height: 32px;
+  background-position: center right;
+  background-repeat: no-repeat;
+  background-size: 18px;
+  padding-right: 30px;
+  display: block;
+  width: 240px;
+  padding: 3px 8px 3px 5px;
+  border-bottom: 1px solid #f8f8f8;
+  &:hover{
+    background-position: -100% 0;
+    color: orange; 
+  }
+}
+
+
+.header {
+  padding: 0 60px;
+  font-family: "Source Sans Pro", Helvetica, Arial, 游ゴシック体, YuGothic, メイリオ, Meiryo, sans-serif;
+  &__box {
+    margin: 0 auto;
+    height: 100%;
+    min-height: 82px;
+    width: 100%;
+    max-width: 1040px;
+    &__main {
+      padding-top: 15px;
+      padding-bottom: 10px;
+      &--icon {
+        // background-image: image-url("logo.png");
+        height: 40px;
+        width: 140px;
+        background-size: cover;
+      }
+    }
+    &__sub {
+      display: flex;
+      justify-content: space-between;
+      margin-bottom: 10px;
+      line-height: 32px;
+      padding-top: 1px;
+      &__left {
+        display: flex;
+        font-size: 14px;
+        &--category {
+          padding-right: 30px;
+          position: relative;
+          &:hover > .visibleTree{
+            opacity: 1;
+            visibility: visible;
+          }
+          .visibleTree{
+            opacity: 0;
+            visibility: hidden;
+            position: absolute;
+            display: flex;
+            top: 100%;
+            z-index: 2;
+            background-color: white;
+            .firstMenu__parents{
+              width: 240px;
+              &__parent{
+              &:hover > .secondMenu__children{
+                opacity: 1;
+                visibility: visible;
+              }
+              }
+              .secondMenu__children{
+                position: absolute;
+                top: 0px;
+                left: 100%;
+                opacity: 0;
+                visibility: hidden;
+                background-color: white;
+                  &__child{
+                  &:hover > .thirdMenu__grandchildren{
+                  opacity: 1;
+                  visibility: visible;
+                  }
+                  }
+                    .thirdMenu__grandchildren{
+                      background-color: white;
+                      position: absolute;
+                      left: 100%;
+                      top: 0px;
+                      opacity: 0;
+                      visibility: hidden;
+                      &__grandchild{
+                        background-color: white;
+                      }
+                    }
+                }
+              }
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/_posts.scss
+++ b/app/assets/stylesheets/_posts.scss
@@ -62,7 +62,6 @@
             text-decoration: none;
             height: 20px;
             color: #333;
-            width: 70px;
             :hover{color: orange;}
             .t__head__bar__search__box-category{}
           }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -28,7 +28,8 @@
  @import "user_index.scss";
  @import "new_card.scss";
  @import "edit_card.scss";
- @import "log_in.scss"
+ @import "log_in.scss";
+ @import "category.scss"
 
 
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :set_category, only: [:new, :create, :edit, :update]
+  before_action :set_category, only: [:new, :create, :edit, :update, :top]
   before_action :set_item, only: [:update, :edit, :destroy]
   before_action :move_to_root, except: [:index, :show, :top]
   def index

--- a/app/views/layouts/_category.html.haml
+++ b/app/views/layouts/_category.html.haml
@@ -1,0 +1,18 @@
+.header__box__sub__left--category
+  = link_to "#", class: "categoryBtn", id: "left-category" do
+    = "カテゴリー"
+  .visibleTree
+    %ul.firstMenu__parents
+      - @category_parent_array.each do |parent|
+        %li.firstMenu__parents__parent
+          = link_to "#{parent.name}", "#", class: "item-link" 
+
+          %ul.secondMenu__children
+            - parent.children.each do |child|
+              %li.secondMenu__children__child
+                = link_to "#{child.name}", "#", class: "item-link" 
+
+                %ul.thirdMenu__grandchildren
+                  - child.children.each do |grandchildren|
+                    %li.thirdMenu__grandchildren__grandchild
+                      = link_to "#{grandchildren.name}", "#", class: "item-link" 

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -11,7 +11,7 @@
     .t__head__bar__search
       .t__head__bar__search__box
         %a(id="categoryBtn" href="/")
-          .t__head__bar__search__box-categoryカテゴリー
+          = render 'layouts/category'
         %a(id="brandBtn" href="/")
           .t__head__bar__search__box-brandブランド
       .t__head__bar__search__select


### PR DESCRIPTION
# what
トップページのカテゴリ表示の見た目変更
# why
トップページのカテゴリボタンからカテゴリ一覧表示へ進む機能を実装する際に、カテゴリを枝分かれで一括表示できる必要があったため