### PR TITLE
条件分岐の追加

### DIFF
--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -90,7 +90,10 @@
             or
             %li
               = button_to "この商品を削除する", item_path(@item), method: :delete, data: {confirm: "削除しますか？"}
-
+          -elsif user_signed_in? == false
+            = link_to new_user_session_path do
+              %button.d-itemChangeBox__btnList__buyBtn
+                ログインして購入する
           -else
             %li
               = link_to item_purchase_index_path(@item.id) do


### PR DESCRIPTION
# what
ログインしていないユーザーには購入画面ではなくてログインページに転移させるように変更
# why
ログインしていないクライアントが購入ページに移動したさいにエラーが起きるのでそれを防ぐため