### PR TITLE
トップページにカテゴリ一覧機能

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -2,6 +2,6 @@ class CategoriesController < ApplicationController
 
   def show 
     @category = Category.find(params[:id])
-    @items = @category.items.page(params[:page]).per(5)
+    @items = @category.items.order('created_at DESC').page(params[:page]).per(5)
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -58,6 +58,8 @@ class ItemsController < ApplicationController
 
   def top
     @items = Item.includes(:images).order('created_at DESC').limit(3)
+    @category = Item.where(category_id: 1).includes(:images).order('created_at DESC').limit(3)
+    
   end
   
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -58,7 +58,7 @@ class ItemsController < ApplicationController
 
   def top
     @items = Item.includes(:images).order('created_at DESC').limit(3)
-    @category = Item.where(category_id: 1).includes(:images).order('created_at DESC').limit(3)
+    @category = Item.where(category_id: [1...200]).includes(:images).order('created_at DESC').limit(3)
     
   end
   

--- a/app/views/items/_category.html.haml
+++ b/app/views/items/_category.html.haml
@@ -1,0 +1,17 @@
+= link_to item_path(item.id) do
+  .e__middle__container__border
+    .e__middle__container__border__content
+      .e__middle__container__border__content__image
+        = image_tag item.images[0].src.url
+        -if item.buyer_id.present?
+          .e__middle__container__border__content__image--triangle
+          .e__middle__container__border__content__image__soldout
+            SOLD
+      .e__middle__container__border__content__info
+        .e__middle__container__border__content__info__name
+          = item.name
+        .e__middle__container__border__content__info__price
+          ¥
+          = item.price
+          =icon('far','heart') do
+            %span 100

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -44,7 +44,8 @@
               %tr
                 %th カテゴリー
                 %td.d-table--blue
-                  =@item.category.name
+                  = link_to category_path(@item.category.id) do
+                    =@item.category.name
               %tr
                 %th ブランド
                 %td 

--- a/app/views/items/top.html.haml
+++ b/app/views/items/top.html.haml
@@ -100,7 +100,7 @@
       -@category.each do |category|
         = render partial: "items/category", locals:{item: category}
     .t__pickup__index__more
-      = link_to 'もっと見る>',category_path(1)
+
    
 
 .t__bottom

--- a/app/views/items/top.html.haml
+++ b/app/views/items/top.html.haml
@@ -93,8 +93,15 @@
       = link_to 'もっと見る>',items_path
 .t__pickup
   .t__pickup__category
-    %h2 ピックアップブランド
-    %h3 アーカイバ
+    %h2 ピックアップカテゴリー
+    %h3 レディース
+  .t__pickup__index
+    .t__pickup__index__new
+      -@category.each do |category|
+        = render partial: "items/category", locals:{item: category}
+    .t__pickup__index__more
+      = link_to 'もっと見る>',category_path(1)
+   
 
 .t__bottom
   .t__bottom__innner


### PR DESCRIPTION
# What
- トップページにレディースカテゴリを表示
whereメソッドで条件を指定して該当するものをDBから引っ張ってきている。
- カテゴリ一覧表示はカテゴリIDを元に表示させており、ancestryと対応できていないため子要素孫要素の分までの表示は実装できていない
その為トップページには「もっと見る」は実装していない。
- 商品詳細表示のカテゴリに設定していたリンクが無くなっていた為、修正。
- カテゴリー別の商品一覧表示を新着順に修正。

# Why
-トップページを充実させる為。

# トップページのレイアウト
[![Screenshot from Gyazo](https://gyazo.com/bcd9eb674c27a1009ee698e22fa987f9/raw)](https://gyazo.com/bcd9eb674c27a1009ee698e22fa987f9)

# レディースにミニスカートが含まれていない
[![Screenshot from Gyazo](https://gyazo.com/1cd5bea47b40b8c02dcd7b3e0dec24f7/raw)](https://gyazo.com/1cd5bea47b40b8c02dcd7b3e0dec24f7)
