### PR TITLE
購入にurlで直飛びできなくする

### DIFF
--- a/app/controllers/purchase_controller.rb
+++ b/app/controllers/purchase_controller.rb
@@ -1,8 +1,9 @@
 class PurchaseController < ApplicationController
   before_action :set_category
   require 'payjp'
-  before_action :set_item, only: [:index, :pay]
-  before_action :set_card, only: [:index, :pay]
+  before_action :set_item,       only: [:index, :pay]
+  before_action :set_card,       only: [:index, :pay]
+  before_action :no_direct_path, only: [:index, :pay]
   
   def index
     @city = Prefecture.find(current_user.address.city).name
@@ -21,6 +22,9 @@ class PurchaseController < ApplicationController
   end
 
   def pay
+    if @item.buyer_id.present?
+      redirect_to item_path(@item.id)
+    end
     @card = Card.where(user_id: current_user.id).first
     Payjp.api_key = ENV['PAYJP_PRIVATE_KEY']
     Payjp::Charge.create(
@@ -48,6 +52,12 @@ class PurchaseController < ApplicationController
       Category.where(ancestry: nil).each do |parent|
         @category_parent_array << parent
       end
+  end
+
+  def no_direct_path
+    if  @item.user_id == current_user.id
+      redirect_to item_path(@item.id)
+    end
   end
 
 end

--- a/app/controllers/purchase_controller.rb
+++ b/app/controllers/purchase_controller.rb
@@ -4,7 +4,8 @@ class PurchaseController < ApplicationController
   before_action :set_item,       only: [:index, :pay]
   before_action :set_card,       only: [:index, :pay]
   before_action :no_direct_path, only: [:index, :pay]
-  
+  before_action :buyer_id?,      only: [:index, :pay]
+
   def index
     @city = Prefecture.find(current_user.address.city).name
     @card = Card.where(user_id: current_user.id).first
@@ -22,9 +23,6 @@ class PurchaseController < ApplicationController
   end
 
   def pay
-    if @item.buyer_id.present?
-      redirect_to item_path(@item.id)
-    end
     @card = Card.where(user_id: current_user.id).first
     Payjp.api_key = ENV['PAYJP_PRIVATE_KEY']
     Payjp::Charge.create(
@@ -56,6 +54,12 @@ class PurchaseController < ApplicationController
 
   def no_direct_path
     if  @item.user_id == current_user.id
+      redirect_to item_path(@item.id)
+    end
+  end
+
+  def buyer_id?
+    if @item.buyer_id.present?
       redirect_to item_path(@item.id)
     end
   end


### PR DESCRIPTION
# what
自身が出品した商品の購入画面へURLを直打ちしても飛べないようになっている

自身が出品した商品は、支払いを作成するアクション(Payjp::Charge.createをするアクション)を動かせないようになっている

一度購入された商品は、支払いを作成するアクションをできなくす
# why
セキュリテイ維持のため